### PR TITLE
Set the slack token file in the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Updates your Slack status depending on the SSID of the Wifi network you are conn
 2. Create an access token at https://api.slack.com/custom-integrations/legacy-tokens for your workspace (i.e devartis).
 3. Create a file named `slack-token.config` with the generated token in it and save it at the root of the repository. This file should have just one line with the token.
 4. Run `mv slack-token.config ~/.slack-token.config` in order to hidde this file, and to be used by the script.
-5. Run `sudo mv slack.sh /etc/network/if-up.d/slack`.
+5. Run `sudo cp slack.sh /etc/network/if-up.d/slack`.
 6. Enjoy the automatic slack status changing!
 
 ## Inspiration

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Updates your Slack status depending on the SSID of the Wifi network you are conn
 
 ## Installation
 
-1. Clone this repository on your filesystem.
-1. Create an access token at https://api.slack.com/custom-integrations/legacy-tokens for your workspace (i.e devartis).
-1. Create a file named `token.config` with the generated token in it and save it at the root of the repository. This file should have just one line with the token.
-1. From the root of the repository run `sudo ln -s slack.sh /etc/network/if-up.d/slack`.
+1. Run `clone https://github.com/devartis/slack-status.git && cd slack-status`
+2. Create an access token at https://api.slack.com/custom-integrations/legacy-tokens for your workspace (i.e devartis).
+3. Create a file named `slack-token.config` with the generated token in it and save it at the root of the repository. This file should have just one line with the token.
+4. Run `mv slack-token.config ~/.slack-token.config` in order to hidde this file, and to be used by the script.
+5. Run `sudo mv slack.sh /etc/network/if-up.d/slack`.
+6. Enjoy the automatic slack status changing!
 
 ## Inspiration
 

--- a/slack.sh
+++ b/slack.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-	DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-	SOURCE="$(readlink "$SOURCE")"
-	[[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-done
-DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-cd $DIR
-
-TOKEN=$(<token.config)
+#NON_ROOT_USERNAME=$SUDO_USER
+TOKEN=$(</home/$SUDO_USER/.slack-token.config)
 SSID=$(iwgetid -r)
 
 if [ $SSID == 'devartisUFO' ]

--- a/slack.sh
+++ b/slack.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-#NON_ROOT_USERNAME=$SUDO_USER
-TOKEN=$(</home/$SUDO_USER/.slack-token.config)
+USERNAME=$(who | awk '{print $1}')
+TOKEN=$(</home/$USERNAME/.slack-token.config)
 SSID=$(iwgetid -r)
 
 if [ $SSID == 'devartisUFO' ]


### PR DESCRIPTION
The README now suggests to put the slack token in a hidden file and the script knows where is this file. Is not necessary search it anymore.
  